### PR TITLE
Performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-    - "5"
+    - "8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,44 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "assertion-error": {
@@ -25,6 +56,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -35,24 +72,61 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "check-error": {
@@ -60,6 +134,22 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
     },
     "cli": {
       "version": "1.0.1",
@@ -71,10 +161,58 @@
         "glob": "^7.1.1"
       }
     },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "concat-map": {
@@ -105,13 +243,19 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -122,6 +266,15 @@
         "type-detect": "^4.0.0"
       }
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -129,33 +282,33 @@
       "dev": true
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
       },
       "dependencies": {
         "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
           "dev": true
         },
         "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
           "dev": true
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -177,16 +330,58 @@
         "domelementtype": "1"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "exit": {
@@ -195,10 +390,56 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-func-name": {
@@ -208,9 +449,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -221,22 +462,46 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "htmlparser2": {
@@ -263,10 +528,82 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -274,50 +611,67 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jshint": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.1.tgz",
+      "integrity": "sha512-WXWePB8ssAH3DlD05IoqolsY6arhbll/1+i2JkRPpihQAuiNaR/gSt8VKIcxpV5m6XChP0hCwESQUqpuQMA8Tg==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "3.7.x",
+        "lodash": "~4.17.11",
         "minimatch": "~3.0.2",
         "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
       }
     },
-    "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-      "dev": true
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
     },
     "lodash": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-      "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lolex": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.6.0.tgz",
-      "integrity": "sha512-e1UtIo1pbrIqEXib/yMjHciyqkng5lc0rrIbytgjmRgDR9+2ceNIAcwOWSgylRjoEP9VdVguCSRwnNmlbnOUwA==",
-      "dev": true
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
     },
     "microdash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.3.0.tgz",
-      "integrity": "sha1-TQ0yKY1UllS9lIhGAzkzqBwdkjs="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.0.tgz",
+      "integrity": "sha512-NzJ6hCeuFOaXe7RUc1SpSjwEHvUxmEIGsiRn5Nx8Dv3Pk3+fLVe51W3ASSAkVoebPloXZWEGUoUk/05NVbVCMw=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -329,57 +683,95 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
-      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "mkdirp": "0.5.5",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
-    "nise": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "nowdoc": {
       "version": "1.0.1",
@@ -391,6 +783,40 @@
         "template-string": "^1.1.0"
       }
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -400,25 +826,52 @@
         "wrappy": "1"
       }
     },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "readable-stream": {
@@ -433,10 +886,37 @@
         "string_decoder": "~0.10.x"
       }
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shelljs": {
@@ -445,49 +925,78 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
-    "sinon": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-5.0.7.tgz",
-      "integrity": "sha512-GvNLrwpvLZ8jIMZBUhHGUZDq5wlUdceJWyHvZDmqBxnjazpxY1L0FNbGBX6VpcOEoQ8Q4XMWFzm2myJMvx+VjA==",
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
-    "sinon-chai": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
-      "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
-      "dev": true
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
     },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "1.0.4",
@@ -496,12 +1005,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "template-string": {
@@ -510,11 +1019,14 @@
       "integrity": "sha1-97LAstPTuJVTVAQ8jwOEzujpf0w=",
       "dev": true
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "type-detect": {
       "version": "4.0.8",
@@ -522,11 +1034,147 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,15 +25,14 @@
     "test": "npm run jshint && npm run mocha"
   },
   "dependencies": {
-    "microdash": "^1.0.0"
+    "microdash": "^1.4.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "jshint": "^2.9.5",
-    "mocha": "^5.1.1",
-    "nowdoc": "^1.0.1",
-    "sinon": "^5.0.7",
-    "sinon-chai": "^3.0.0"
+    "chai": "^4.2.0",
+    "jshint": "^2.11.1",
+    "lodash": "^4.17.15",
+    "mocha": "^7.1.2",
+    "nowdoc": "^1.0.1"
   },
   "engines": {
     "node": ">=0.6"

--- a/src/Component.js
+++ b/src/Component.js
@@ -12,14 +12,12 @@
 var _ = require('microdash'),
     copy = require('./copy'),
     getColumnNumber = require('./getColumnNumber'),
-    getLineNumber = require('./getLineNumber'),
-    undef;
+    getLineNumber = require('./getLineNumber');
 
-function Component(parser, matchCache, qualifierName, qualifier, arg, args, name, captureBoundsAs) {
+function Component(parser, qualifierName, qualifier, arg, args, name, captureBoundsAs) {
     this.arg = arg;
     this.args = args;
     this.captureBoundsAs = args.captureBoundsAs || captureBoundsAs;
-    this.matchCache = matchCache;
     this.name = name;
     this.parser = parser;
     this.qualifier = qualifier;
@@ -33,12 +31,8 @@ _.extend(Component.prototype, {
 
     match: function (text, offset, options) {
         var component = this,
-            match = component.matchCache[offset],
+            match,
             subMatch;
-
-        if (match !== undef) {
-            return match;
-        }
 
         // Cascade ignoreWhitespace down to descendants of this component
         if (component.args.ignoreWhitespace === false) {
@@ -54,7 +48,6 @@ _.extend(Component.prototype, {
         subMatch = component.qualifier(text, offset, component.arg, component.args, options);
 
         if (subMatch === null) {
-            component.matchCache[offset] = null;
             return null;
         }
 
@@ -74,8 +67,6 @@ _.extend(Component.prototype, {
                 match = subMatch;
             }
         }
-
-        component.matchCache[offset] = match;
 
         return match;
     }

--- a/src/Component.js
+++ b/src/Component.js
@@ -10,26 +10,73 @@
 'use strict';
 
 var _ = require('microdash'),
-    copy = require('./copy'),
-    getColumnNumber = require('./getColumnNumber'),
-    getLineNumber = require('./getLineNumber');
+    copy = require('./copy');
 
+/**
+ * Represents a term or group term in a grammar rule. The "root" of a rule
+ * is also represented with a component.
+ *
+ * @param {Parser} parser
+ * @param {string} qualifierName
+ * @param {Function} qualifier
+ * @param {*} arg
+ * @param {Object} args
+ * @param {string} name
+ * @param {string=} captureBoundsAs
+ * @constructor
+ */
 function Component(parser, qualifierName, qualifier, arg, args, name, captureBoundsAs) {
+    /**
+     * @type {*}
+     */
     this.arg = arg;
+    /**
+     * @type {Object}
+     */
     this.args = args;
+    /**
+     * @type {string|null}
+     */
     this.captureBoundsAs = args.captureBoundsAs || captureBoundsAs;
+    /**
+     * @type {string}
+     */
     this.name = name;
+    /**
+     * @type {Parser}
+     */
     this.parser = parser;
+    /**
+     * @type {Function}
+     */
     this.qualifier = qualifier;
+    /**
+     * @type {string}
+     */
     this.qualifierName = qualifierName;
 }
 
 _.extend(Component.prototype, {
+    /**
+     * Fetches the name to be used to capture the bounds of this component
+     *
+     * @return {string|null}
+     */
     getOffsetCaptureName: function () {
         return this.captureBoundsAs;
     },
 
-    match: function (text, offset, options) {
+    /**
+     * Attempts to match this component at the given offset
+     *
+     * @param {string} text
+     * @param {number} offset
+     * @param {number} line
+     * @param {number} lineOffset
+     * @param {Object} options
+     * @return {Object|null} Returns the match object on success or null on failure
+     */
+    match: function (text, offset, line, lineOffset, options) {
         var component = this,
             match,
             subMatch;
@@ -45,7 +92,7 @@ _.extend(Component.prototype, {
             });
         }
 
-        subMatch = component.qualifier(text, offset, component.arg, component.args, options);
+        subMatch = component.qualifier(text, offset, line, lineOffset, component.arg, component.args, options);
 
         if (subMatch === null) {
             return null;
@@ -84,18 +131,21 @@ function allElementsAreStrings(array) {
 }
 
 function mergeCaptures(subMatch, component, text, offset) {
-    var match;
+    var match = {
+        firstLine: subMatch.firstLine,
+        firstLineOffset: subMatch.firstLineOffset,
+        lines: subMatch.lines,
+        lastLine: subMatch.lastLine,
+        lastLineOffset: subMatch.lastLineOffset,
+        textOffset: subMatch.textOffset,
+        textLength: subMatch.textLength
+    };
 
     if (allElementsAreStrings(subMatch.components)) {
-        match = {
-            components: subMatch.components.join(''),
-            textLength: subMatch.textLength
-        };
+        match.components = subMatch.components.join('');
     } else {
-        match = {
-            components: {},
-            textLength: subMatch.textLength
-        };
+        match.components = {};
+
         _.each(subMatch.components, function (value) {
             if (_.isPlainObject(value)) {
                 copy(match.components, value);
@@ -106,13 +156,13 @@ function mergeCaptures(subMatch, component, text, offset) {
             match.components[component.captureBoundsAs] = {
                 start: {
                     offset: offset + subMatch.textOffset,
-                    line: getLineNumber(text, offset + subMatch.textOffset),
-                    column: getColumnNumber(text, offset + subMatch.textOffset)
+                    line: subMatch.firstLine + 1,
+                    column: offset + subMatch.textOffset - subMatch.firstLineOffset + 1
                 },
                 end: {
                     offset: offset + subMatch.textOffset + subMatch.textLength,
-                    line: getLineNumber(text, offset + subMatch.textOffset + subMatch.textLength),
-                    column: getColumnNumber(text, offset + subMatch.textOffset + subMatch.textLength)
+                    line: subMatch.lastLine + 1,
+                    column: offset + subMatch.textOffset + subMatch.textLength - subMatch.lastLineOffset + 1
                 }
             };
         }
@@ -122,19 +172,24 @@ function mergeCaptures(subMatch, component, text, offset) {
         match.components.name = subMatch.name;
     }
 
-    match.textOffset = subMatch.textOffset;
-
     return match;
 }
 
 function createSubMatch(text, subMatch, component, offset) {
     // Component is named: don't attempt to merge an array in
-    var match = {
-        components: {},
-        isEmpty: subMatch.isEmpty || false,
-        textLength: subMatch.textLength,
-        textOffset: subMatch.textOffset
-    };
+    var startOffset = offset + subMatch.textOffset,
+        match = {
+            components: {},
+            isEmpty: subMatch.isEmpty || false,
+            firstLine: subMatch.firstLine,
+            firstLineOffset: subMatch.firstLineOffset,
+            lines: subMatch.lines,
+            lastLine: subMatch.lastLine,
+            lastLineOffset: subMatch.lastLineOffset,
+            textLength: subMatch.textLength,
+            textOffset: subMatch.textOffset
+        };
+
     if (subMatch.name) {
         match.components.name = subMatch.name;
     }
@@ -143,20 +198,18 @@ function createSubMatch(text, subMatch, component, offset) {
     }
 
     if (component.captureBoundsAs) {
-        (function (offset) {
-            match.components[component.captureBoundsAs] = {
-                start: {
-                    offset: offset,
-                    line: getLineNumber(text, offset),
-                    column: getColumnNumber(text, offset)
-                },
-                end: {
-                    offset: offset + subMatch.textLength,
-                    line: getLineNumber(text, offset + subMatch.textLength),
-                    column: getColumnNumber(text, offset + subMatch.textLength)
-                }
-            };
-        }(offset + match.textOffset));
+        match.components[component.captureBoundsAs] = {
+            start: {
+                offset: startOffset,
+                line: subMatch.firstLine + 1,
+                column: startOffset - subMatch.firstLineOffset + 1
+            },
+            end: {
+                offset: startOffset + subMatch.textLength,
+                line: subMatch.lastLine + 1,
+                column: startOffset + subMatch.textLength - subMatch.lastLineOffset + 1
+            }
+        };
     }
 
     return match;

--- a/src/Exception/Parse.js
+++ b/src/Exception/Parse.js
@@ -14,6 +14,17 @@ var _ = require('microdash'),
     util = require('util'),
     Exception = require('./Exception');
 
+/**
+ * Represents a failed parse attempt
+ *
+ * @param {string} message The error message
+ * @param {string} text The original text string being parsed
+ * @param {Object|null} furthestMatch
+ * @param {number} furthestMatchOffset
+ * @param {Object|null} furthestIgnoreMatch
+ * @param {number} furthestIgnoreMatchOffset
+ * @constructor
+ */
 function ParseException(
     message,
     text,
@@ -24,16 +35,36 @@ function ParseException(
 ) {
     Exception.call(this, message);
 
+    /**
+     * @type {Object|null}
+     */
     this.furthestIgnoreMatch = furthestIgnoreMatch;
+    /**
+     * @type {number}
+     */
     this.furthestIgnoreMatchOffset = furthestIgnoreMatchOffset;
+    /**
+     * @type {Object|null}
+     */
     this.furthestMatch = furthestMatch;
+    /**
+     * @type {number}
+     */
     this.furthestMatchOffset = furthestMatchOffset;
+    /**
+     * @type {string}
+     */
     this.text = text;
 }
 
 util.inherits(ParseException, Exception);
 
 _.extend(ParseException.prototype, {
+    /**
+     * Fetches the furthest 0-based absolute offset that the parse reached before terminating
+     *
+     * @return {number}
+     */
     getFurthestMatchEnd: function () {
         var exception = this;
 
@@ -41,19 +72,35 @@ _.extend(ParseException.prototype, {
             return exception.furthestIgnoreMatchOffset + exception.furthestIgnoreMatch.textLength;
         }
 
-        return exception.furthestMatchOffset + exception.furthestMatch.textLength;
+        return exception.furthestMatchOffset + (exception.furthestMatch ? exception.furthestMatch.textLength : 0);
     },
 
+    /**
+     * Fetches the 1-based line number that the parse reached before terminating
+     *
+     * @return {number}
+     */
     getLineNumber: function () {
         var exception = this;
 
         return getLineNumber(exception.text, exception.getFurthestMatchEnd());
     },
 
+    /**
+     * Fetches the entire source text string being parsed
+     *
+     * @return {string}
+     */
     getText: function () {
         return this.text;
     },
 
+    /**
+     * Determines whether the parse failed due to unexpectedly reaching the end of the source string
+     * (vs. terminating too early and leaving some of the string unparsed)
+     *
+     * @return {boolean}
+     */
     unexpectedEndOfInput: function () {
         var exception = this;
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -254,7 +254,7 @@ function Parser(grammarSpec, stderr, options) {
 
         // Special BeginningOfFile rule
         rules['<BOF>'] = new Rule(parser, createMatchCache(), '<BOF>', null, null);
-        rules['<BOF>'].setComponent(new Component(parser, createMatchCache(), 'what', qualifiers.what, function (text, offset, textOffset) {
+        rules['<BOF>'].setComponent(new Component(parser, 'what', qualifiers.what, function (text, offset, textOffset) {
             return offset === 0 ? {
                 components: '',
                 textLength: 0,
@@ -264,7 +264,7 @@ function Parser(grammarSpec, stderr, options) {
 
         // Special EndOfFile rule
         rules['<EOF>'] = new Rule(parser, createMatchCache(), '<EOF>', null, null);
-        rules['<EOF>'].setComponent(new Component(parser, createMatchCache(), 'what', qualifiers.what, function (text, offset, textOffset) {
+        rules['<EOF>'].setComponent(new Component(parser, 'what', qualifiers.what, function (text, offset, textOffset) {
             return offset + textOffset === text.length ? {
                 components: '',
                 textLength: 0,
@@ -395,7 +395,6 @@ function Parser(grammarSpec, stderr, options) {
 
                 return new Component(
                     parser,
-                    createMatchCache(),
                     qualifierName,
                     qualifiers[qualifierName],
                     arg,

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -76,6 +76,9 @@ _.extend(Rule.prototype, {
         match = rule.component.match(text, offset, options);
 
         if (match === null) {
+            // Record the fact that this rule did _not_ match, so we don't attempt to match it again
+            rule.matchCache[offset] = null;
+
             return null;
         }
 

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -25,7 +25,15 @@ var _ = require('microdash'),
  * @param {Object|null} options
  * @constructor
  */
-function Rule(parser, matchCache, name, captureName, ifNoMatch, processor, options) {
+function Rule(
+    parser,
+    matchCache,
+    name,
+    captureName,
+    ifNoMatch,
+    processor,
+    options
+) {
     /**
      * @type {string|null}
      */
@@ -61,7 +69,17 @@ function Rule(parser, matchCache, name, captureName, ifNoMatch, processor, optio
 }
 
 _.extend(Rule.prototype, {
-    match: function (text, offset, options) {
+    /**
+     * Attempts to match this rule at the given offset into the string
+     *
+     * @param {string} text
+     * @param {number} offset 0-based absolute offset into the string to match at
+     * @param {number} line 0-based number of the current line
+     * @param {number} lineOffset 0-based absolute offset of the start of the current line
+     * @param {Object} options
+     * @return {Object|null}
+     */
+    match: function (text, offset, line, lineOffset, options) {
         var capturedOffset,
             component,
             rule = this,
@@ -73,7 +91,7 @@ _.extend(Rule.prototype, {
 
         options = options || {};
 
-        match = rule.component.match(text, offset, options);
+        match = rule.component.match(text, offset, line, lineOffset, options);
 
         if (match === null) {
             // Record the fact that this rule did _not_ match, so we don't attempt to match it again
@@ -89,6 +107,11 @@ _.extend(Rule.prototype, {
         if (rule.ifNoMatch && (!(component = match.components[rule.ifNoMatch.component]) || component.length === 0)) {
             match = {
                 components: match.components[rule.ifNoMatch.capture],
+                firstLine: match.firstLine,
+                firstLineOffset: match.firstLineOffset,
+                lines: match.lines,
+                lastLine: match.lastLine,
+                lastLineOffset: match.lastLineOffset,
                 textOffset: match.textOffset,
                 textLength: match.textLength
             };
@@ -123,6 +146,13 @@ _.extend(Rule.prototype, {
         return match;
     },
 
+    /**
+     * Sets the root component of this rule
+     * (must be done via a setter to solve the circular dependency issue
+     * when rules in the grammar are recursive)
+     *
+     * @param {Component} component
+     */
     setComponent: function (component) {
         this.component = component;
     }

--- a/src/copy.js
+++ b/src/copy.js
@@ -21,4 +21,5 @@ function copy(to, from) {
     }
 }
 
-module.exports = copy;
+// Use native Object.assign(...) if available for speed
+module.exports = Object.assign || copy;

--- a/src/countNewlines.js
+++ b/src/countNewlines.js
@@ -1,0 +1,26 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var REGEX = /\r?\n/g;
+
+/**
+ * Counts the number of newlines in the given string
+ *
+ * @param {string} text
+ * @return {number}
+ */
+function countNewlines(text) {
+    var match = text.match(REGEX);
+
+    return match ? match.length : 0;
+}
+
+module.exports = countNewlines;

--- a/src/findLastNewlineFrom.js
+++ b/src/findLastNewlineFrom.js
@@ -1,0 +1,35 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+/**
+ * Finds the offset of the most recent newline back from the given offset
+ *
+ * @param {string} text
+ * @param {number} offset
+ * @return {number}
+ */
+function findLastNewlineFrom(text, offset) {
+    // NB: \r is not mentioned here, but should usually be paired with \r\n
+    //     if present (on Windows), so as the \n is last it should not matter
+    //     due to a reverse search being used. If a classic Mac line-ending format
+    //     (only \r) was used then this would be an issue, though.
+    var newlineOffset = text.lastIndexOf('\n', offset);
+
+    if (newlineOffset === -1) {
+        newlineOffset = 0;
+    } else {
+        newlineOffset++; // Accommodate the width of the newline char itself
+    }
+
+    return newlineOffset;
+}
+
+module.exports = findLastNewlineFrom;

--- a/test/unit/Parser/allOfQualifierTest.js
+++ b/test/unit/Parser/allOfQualifierTest.js
@@ -1,0 +1,52 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "allOf" qualifier', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        // Implicit "allOf" qualifier by using an array of rule components
+                        components: [{name: 'my_capture', what: /my\s+\w+/}]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: 'my\n text',
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 10,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/oneOfQualifierTest.js
+++ b/test/unit/Parser/oneOfQualifierTest.js
@@ -1,0 +1,56 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "oneOf" qualifier', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: {
+                            oneOf: [
+                                {name: 'your_capture', what: /your\n \w+/},
+                                {name: 'my_capture', what: /my\n \w+/}
+                            ]
+                        }
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: 'my\n text',
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 10,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/oneOrMoreOfTest.js
+++ b/test/unit/Parser/oneOrMoreOfTest.js
@@ -1,0 +1,80 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "oneOrMoreOf" qualifier', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: {name: 'my_capture', oneOrMoreOf: {what: /my\n \w+/}}
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n first my\n second  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: ['my\n first', 'my\n second'],
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 22,
+                    line: 3,
+                    column: 8
+                }
+            }
+        });
+    });
+
+    it('should fail the match when the qualifier does not match anything', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: {name: 'my_capture', oneOrMoreOf: {what: /my\n \w+/}}
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = 'your\n first your\n second  ';
+
+        try {
+            parser.parse(code);
+        } catch (error) {
+            expect(error.message).to.equal('Parser.parse() :: Unexpected "y"');
+            expect(error.getFurthestMatchEnd()).to.equal(-1);
+            return;
+        }
+
+        throw new Error('Parse should have failed!');
+    });
+});

--- a/test/unit/Parser/optionallyQualifierTest.js
+++ b/test/unit/Parser/optionallyQualifierTest.js
@@ -1,0 +1,91 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "optionally" qualifier', function () {
+    it('should support capturing bounds for every AST node', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_stuff': {
+                        components: [{name: 'my', what: /my/}, {optionally: {name: 'stuff_word', what: /stuff/}}]
+                    },
+                    'my_rule': {
+                        components: {name: 'my_capture', oneOrMoreOf: 'my_stuff'}
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n stuff my\n  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: [
+                {
+                    name: 'my_stuff',
+                    my: 'my',
+                    stuff_word: 'stuff',
+
+                    my_bounds: {
+                        start: {
+                            offset: 2,
+                            line: 1,
+                            column: 3
+                        },
+                        end: {
+                            offset: 11,
+                            line: 2,
+                            column: 7
+                        }
+                    }
+                },
+                {
+                    name: 'my_stuff',
+                    my: 'my',
+                    // NB: Note that "stuff_word" is not captured here at all as it was optional
+
+                    my_bounds: {
+                        start: {
+                            offset: 12,
+                            line: 2,
+                            column: 8
+                        },
+                        end: {
+                            offset: 14,
+                            line: 2,
+                            column: 10
+                        }
+                    }
+                }
+            ],
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 14,
+                    line: 2,
+                    column: 10
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/ruleQualifierTest.js
+++ b/test/unit/Parser/ruleQualifierTest.js
@@ -1,0 +1,92 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "rule" qualifier', function () {
+    it('should support capturing bounds for every AST node with both explicit and implicit rule qualifiers', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_other_rule': {
+                        components: {name: 'my_text', what: /my\n\n \w+/}
+                    },
+                    'my_rule': {
+                        components: [
+                            // Explicitly use a "rule" qualifier
+                            {name: 'first_capture', rule: 'my_other_rule'},
+                            // Implicitly use a "rule" qualifier via the generic "what" qualifier
+                            {name: 'second_capture', what: 'my_other_rule'}
+                        ]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '   my\n\n stuff my\n\n things  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            first_capture: {
+                name: 'my_other_rule',
+                my_text: 'my\n\n stuff',
+
+                my_bounds: {
+                    start: {
+                        offset: 3,
+                        line: 1,
+                        column: 4
+                    },
+                    end: {
+                        offset: 13,
+                        line: 3,
+                        column: 7
+                    }
+                }
+            },
+            second_capture: {
+                name: 'my_other_rule',
+                my_text: 'my\n\n things',
+
+                my_bounds: {
+                    start: {
+                        offset: 14,
+                        line: 3,
+                        column: 8
+                    },
+                    end: {
+                        offset: 25,
+                        line: 5,
+                        column: 8
+                    }
+                }
+            },
+            my_bounds: {
+                start: {
+                    offset: 3,
+                    line: 1,
+                    column: 4
+                },
+                end: {
+                    offset: 25,
+                    line: 5,
+                    column: 8
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/specialBofRuleTest.js
+++ b/test/unit/Parser/specialBofRuleTest.js
@@ -1,0 +1,53 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser special Beginning-Of-File <BOF> rule', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [
+                            {name: 'my_capture', what: ['<BOF>', /my\s+\w+/]}
+                        ]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = 'my\n text  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: 'my\n text',
+            my_bounds: {
+                start: {
+                    offset: 0,
+                    line: 1,
+                    column: 1
+                },
+                end: {
+                    offset: 8,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/specialEofRuleTest.js
+++ b/test/unit/Parser/specialEofRuleTest.js
@@ -1,0 +1,53 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser special End-Of-File <EOF> rule', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [
+                            {name: 'my_capture', what: [/my\s+\w+/, '<EOF>']}
+                        ]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: 'my\n text',
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 10,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/whatQualifierTest.js
+++ b/test/unit/Parser/whatQualifierTest.js
@@ -1,0 +1,76 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "what" qualifier', function () {
+    it('should support capturing bounds for every AST node', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_other_rule': {
+                        components: {name: 'my_other_capture', what: /my\n\n \w+/}
+                    },
+                    'my_rule': {
+                        components: [
+                            // Use a regex as the "what"
+                            {name: 'first_capture', what: /my\n\n \w+/},
+                            // Use another rule name as the "what"
+                            {name: 'second_capture', what: 'my_other_rule'}
+                        ]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '   my\n\n stuff my\n\n things  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            first_capture: 'my\n\n stuff',
+            second_capture: {
+                name: 'my_other_rule',
+                my_other_capture: 'my\n\n things',
+
+                my_bounds: {
+                    start: {
+                        offset: 14,
+                        line: 3,
+                        column: 8
+                    },
+                    end: {
+                        offset: 25,
+                        line: 5,
+                        column: 8
+                    }
+                }
+            },
+            my_bounds: {
+                start: {
+                    offset: 3,
+                    line: 1,
+                    column: 4
+                },
+                end: {
+                    offset: 25,
+                    line: 5,
+                    column: 8
+                }
+            }
+        });
+    });
+});

--- a/test/unit/Parser/zeroOrMoreOfQualifierTest.js
+++ b/test/unit/Parser/zeroOrMoreOfQualifierTest.js
@@ -1,0 +1,57 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    Parser = require('../../../src/Parser');
+
+describe('Parser "zeroOrMoreOf" qualifier', function () {
+    it('should support capturing bounds for every AST node with a single rule', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [
+                            {name: 'first_capture', zeroOrMoreOf: {what: /my\n \w+/}},
+                            {name: 'second_capture', zeroOrMoreOf: {what: /your\n \w+/}}
+                        ]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n first my\n second  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            // Two occurrences
+            first_capture: ['my\n first', 'my\n second'],
+            // Second capture did not match anything, but that's fine as we're allowing zero occurrences
+            second_capture: [],
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 22,
+                    line: 3,
+                    column: 8
+                }
+            }
+        });
+    });
+});

--- a/test/unit/ParserTest.js
+++ b/test/unit/ParserTest.js
@@ -1000,7 +1000,7 @@ describe('Parser', function () {
         });
 
         describe('capture all bounds option', function () {
-            it('should support capturing bounds for every AST node', function () {
+            it('should support capturing bounds for every AST node with a complex grammar', function () {
                 var grammarSpec = {
                         ignore: 'whitespace',
                         rules: {

--- a/test/unit/countNewlinesTest.js
+++ b/test/unit/countNewlinesTest.js
@@ -1,0 +1,39 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    countNewlines = require('../../src/countNewlines'),
+    expect = require('chai').expect;
+
+describe('countNewlines()', function () {
+    _.each({
+        'the empty string': {
+            text: '',
+            expectedNewlines: 0
+        },
+        'a blank line followed by text on the next line': {
+            text: '\nabc',
+            expectedNewlines: 1
+        },
+        'three lines of equal length': {
+            text: 'abc\ndef\nghi',
+            expectedNewlines: 2
+        },
+        'three blank lines followed by text on the next line': {
+            text: '\n\n\nmememe',
+            expectedNewlines: 3
+        }
+    }, function (scenario, description) {
+        it('should return the correct newline count for ' + description, function () {
+            expect(countNewlines(scenario.text)).to.equal(scenario.expectedNewlines);
+        });
+    });
+});

--- a/test/unit/findLastNewlineFromTest.js
+++ b/test/unit/findLastNewlineFromTest.js
@@ -1,0 +1,43 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    findLastNewlineFrom = require('../../src/findLastNewlineFrom'),
+    expect = require('chai').expect;
+
+describe('findLastNewlineFrom()', function () {
+    _.each({
+        'the empty string': {
+            text: '',
+            offset: 0,
+            expectedLastNewlineOffset: 0
+        },
+        'mid-way along a single line': {
+            text: 'my text here',
+            offset: 6,
+            expectedLastNewlineOffset: 0
+        },
+        'mid-way along the third line with LF line endings': {
+            text: 'first\nsecond\nand third',
+            offset: 18,
+            expectedLastNewlineOffset: 13 // Offset should be just _after_ the newline sequence
+        },
+        'mid-way along the third line with CRLF line endings': {
+            text: 'first\r\nsecond\r\nand third',
+            offset: 18,
+            expectedLastNewlineOffset: 15 // Offset should be just _after_ the newline sequence
+        }
+    }, function (scenario, description) {
+        it('should return the correct newline count for ' + description, function () {
+            expect(findLastNewlineFrom(scenario.text)).to.equal(scenario.expectedLastNewlineOffset);
+        });
+    });
+});


### PR DESCRIPTION
- Use native `Object.assign(...)` if available for speed
- Remove Component-level caching as it was unused: backtracking
  means components will never be re-matched. Additionally, cache
  misses at the Rule level to avoid re-attempting a rule at the
  same position (if a rule doesn't match at a certain position,
  it never will)
- Speed up bounds calculations by tracking the most recent line and its offset
  rather than always calculating the line & column from an absolute offset