### PR TITLE
Add support for component match modifiers

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -23,7 +23,7 @@ var _ = require('microdash'),
  * @param {Function} qualifier
  * @param {*} arg
  * @param {Object} args
- * @param {string} name
+ * @param {string=} name
  * @param {string=} captureBoundsAs
  * @constructor
  */
@@ -41,7 +41,7 @@ function Component(parser, qualifierName, qualifier, arg, args, name, captureBou
      */
     this.captureBoundsAs = args.captureBoundsAs || captureBoundsAs;
     /**
-     * @type {string}
+     * @type {string|null}
      */
     this.name = name;
     /**
@@ -139,6 +139,7 @@ _.extend(Component.prototype, {
                         error = new ParseException(
                             message,
                             text,
+                            offset + subMatch.textOffset,
                             component.parser.getFurthestMatchEnd(),
                             context
                         ),

--- a/src/Exception/Parse.js
+++ b/src/Exception/Parse.js
@@ -19,6 +19,7 @@ var _ = require('microdash'),
  *
  * @param {string} message The error message
  * @param {string} text The original text string being parsed
+ * @param {number} furthestMatchStart
  * @param {number} furthestMatchEnd
  * @param {Object} context
  * @constructor
@@ -26,6 +27,7 @@ var _ = require('microdash'),
 function ParseException(
     message,
     text,
+    furthestMatchStart,
     furthestMatchEnd,
     context
 ) {
@@ -39,6 +41,10 @@ function ParseException(
      * @type {number}
      */
     this.furthestMatchEnd = furthestMatchEnd;
+    /**
+     * @type {number}
+     */
+    this.furthestMatchStart = furthestMatchStart;
     /**
      * @type {string}
      */
@@ -58,25 +64,69 @@ _.extend(ParseException.prototype, {
     },
 
     /**
-     * Fetches the furthest 0-based absolute offset that the parse reached before terminating
+     * Fetches the last 1-based line number that the parse reached before terminating
      *
      * @return {number}
      */
-    getFurthestMatchEnd: function () {
-        return this.furthestMatchEnd;
-    },
-
-    /**
-     * Fetches the 1-based line number that the parse reached before terminating
-     *
-     * @return {number}
-     */
-    getLineNumber: function () {
+    getEndLineNumber: function () {
         var exception = this;
 
         return exception.furthestMatchEnd === -1 ?
             -1 :
             getLineNumber(exception.text, exception.furthestMatchEnd);
+    },
+
+    /**
+     * Fetches the furthest 0-based absolute offset that the parse reached before terminating
+     *
+     * @return {number}
+     */
+    getEndOffset: function () {
+        return this.furthestMatchEnd;
+    },
+
+    /**
+     * Fetches the furthest 0-based absolute offset that the parse reached before terminating
+     *
+     * @deprecated Use .getEndOffset()
+     * @return {number}
+     */
+    getFurthestMatchEnd: function () {
+        return this.getEndOffset();
+    },
+
+    /**
+     * Fetches the 1-based line number that the parse reached before terminating
+     *
+     * @deprecated Use .getEndLineNumber() instead
+     * @return {number}
+     */
+    getLineNumber: function () {
+        return this.getEndLineNumber();
+    },
+
+    /**
+     * Fetches the first 1-based line number that the parse reached before terminating
+     *
+     * @return {number}
+     */
+    getStartLineNumber: function () {
+        var exception = this;
+
+        return exception.furthestMatchStart === -1 ?
+            -1 :
+            getLineNumber(exception.text, exception.furthestMatchStart);
+    },
+
+    /**
+     * Fetches the 0-based absolute offset of the furthest match that the parse reached before terminating,
+     * at the level where it is relevant (entire parse for a general parse failure, or the component
+     * where a modifier was defined for a custom failure)
+     *
+     * @return {number}
+     */
+    getStartOffset: function () {
+        return this.furthestMatchStart;
     },
 
     /**

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -657,6 +657,22 @@ _.extend(Parser.prototype, {
         return parser.furthestMatchOffset + (parser.furthestMatch ? parser.furthestMatch.textLength : 0);
     },
 
+    /**
+     * Fetches the 0-based offset into the input string at the start
+     * of the furthest match into the string
+     *
+     * @returns {number}
+     */
+    getFurthestMatchStart: function () {
+        var parser = this;
+
+        if (parser.furthestIgnoreMatchOffset > parser.furthestMatchOffset) {
+            return parser.furthestIgnoreMatchOffset;
+        }
+
+        return parser.furthestMatchOffset;
+    },
+
     getState: function () {
         var parser = this;
 
@@ -705,6 +721,7 @@ _.extend(Parser.prototype, {
             matchEnd = 0,
             matchLine,
             matchLastLineOffset,
+            matchStart,
             message,
             whitespaceMatch;
 
@@ -755,16 +772,22 @@ _.extend(Parser.prototype, {
             furthestMatchEnd = parser.getFurthestMatchEnd();
 
             if (furthestMatchEnd === -1) {
+                matchStart = -1;
                 message = 'No match';
-            } else if (furthestMatchEnd === text.length) {
-                message = 'Unexpected end of file';
             } else {
-                message = 'Unexpected "' + text.charAt(furthestMatchEnd) + '"';
+                matchStart = match ? match.textOffset : parser.getFurthestMatchStart();
+
+                if (furthestMatchEnd === text.length) {
+                    message = 'Unexpected end of file';
+                } else {
+                    message = 'Unexpected "' + text.charAt(furthestMatchEnd) + '"';
+                }
             }
 
             error = new ParseException(
                 'Parser.parse() :: ' + message,
                 text,
+                matchStart,
                 furthestMatchEnd,
                 {}
             );

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -141,6 +141,7 @@ _.extend(Rule.prototype, {
                     error = new ParseException(
                         message,
                         text,
+                        offset + match.textOffset,
                         rule.parser.getFurthestMatchEnd(),
                         context
                     ),

--- a/test/unit/Parser/customFailureTest.js
+++ b/test/unit/Parser/customFailureTest.js
@@ -39,7 +39,7 @@ describe('Parser custom failures', function () {
                 bounds: 'my_bounds'
             },
             parser = new Parser(grammarSpec),
-            code = 'first \n\nbut not immediately second';
+            code = '  first \n\nbut not immediately second';
 
         try {
             parser.parse(code);
@@ -50,10 +50,12 @@ describe('Parser custom failures', function () {
         expect(caughtError).to.be.an.instanceOf(ParseException);
         expect(caughtError.getMessage()).to.equal('My failure message');
         expect(caughtError.getContext()).to.deep.equal({my: 'context'});
+        expect(caughtError.getStartOffset()).to.equal(2);
+        expect(caughtError.getStartLineNumber()).to.equal(1);
         // Note that the whitespace after the match was not consumed, as the failure
         // was explicitly raised in the processor callback
-        expect(caughtError.getFurthestMatchEnd()).to.equal(5);
-        expect(caughtError.getLineNumber()).to.equal(1);
+        expect(caughtError.getEndOffset()).to.equal(7);
+        expect(caughtError.getEndLineNumber()).to.equal(1);
         expect(caughtError.getText()).to.equal(code);
         expect(caughtError.unexpectedEndOfInput()).to.be.false;
     });
@@ -115,7 +117,7 @@ describe('Parser custom failures', function () {
             },
             stderr = {my: 'fake stderr'},
             parser = new Parser(grammarSpec, stderr),
-            code = 'first \n\nbut not immediately second',
+            code = '\n\n  first \n\nbut not immediately second',
             result;
 
         result = parser.parse(code);
@@ -125,10 +127,13 @@ describe('Parser custom failures', function () {
         expect(result.parseException).to.be.an.instanceOf(ParseException);
         expect(result.parseException.getMessage()).to.equal('My failure message');
         expect(result.parseException.getContext()).to.deep.equal({my: 'context'});
+        // Note that the whitespace before the match _was_ consumed first
+        expect(result.parseException.getStartOffset()).to.equal(4);
+        expect(result.parseException.getStartLineNumber()).to.equal(3);
         // Note that the whitespace after the match was not consumed, as the failure
         // was explicitly raised in the processor callback
-        expect(result.parseException.getFurthestMatchEnd()).to.equal(5);
-        expect(result.parseException.getLineNumber()).to.equal(1);
+        expect(result.parseException.getEndOffset()).to.equal(9);
+        expect(result.parseException.getEndLineNumber()).to.equal(3);
         expect(result.parseException.getText()).to.equal(code);
         expect(result.parseException.unexpectedEndOfInput()).to.be.false;
     });

--- a/test/unit/Parser/modifierTest.js
+++ b/test/unit/Parser/modifierTest.js
@@ -143,7 +143,7 @@ describe('Parser grammar component match modifier', function () {
                 captureAllBounds: true
             },
             parser = new Parser(grammarSpec, null, options),
-            code = '  my\n text  ';
+            code = '\n\n  my\n text  ';
 
         try {
             parser.parse(code);
@@ -154,10 +154,13 @@ describe('Parser grammar component match modifier', function () {
         expect(caughtError).to.be.an.instanceOf(ParseException);
         expect(caughtError.getMessage()).to.equal('My failure message');
         expect(caughtError.getContext()).to.deep.equal({my: 'context'});
+        // Note that the whitespace before the match _was_ consumed first
+        expect(caughtError.getStartOffset()).to.equal(4);
         // Note that the whitespace after the match was not consumed, as the failure
         // was explicitly raised in the modifier callback
-        expect(caughtError.getFurthestMatchEnd()).to.equal(10);
-        expect(caughtError.getLineNumber()).to.equal(2);
+        expect(caughtError.getEndOffset()).to.equal(12);
+        expect(caughtError.getStartLineNumber()).to.equal(3);
+        expect(caughtError.getEndLineNumber()).to.equal(4);
         expect(caughtError.getText()).to.equal(code);
         expect(caughtError.unexpectedEndOfInput()).to.be.false;
     });

--- a/test/unit/Parser/modifierTest.js
+++ b/test/unit/Parser/modifierTest.js
@@ -68,6 +68,8 @@ describe('Parser grammar component match modifier', function () {
                             what: /my\s+\w+/,
                             modifier: function (capture, parse) {
                                 return capture === 'my\n text' ?
+                                    // Reenter the parser, parsing an entirely different string,
+                                    // and use its result as the result of this component's match
                                     parse('      my \n\n   differenttext  ') :
                                     capture;
                             }

--- a/test/unit/Parser/modifierTest.js
+++ b/test/unit/Parser/modifierTest.js
@@ -1,0 +1,162 @@
+/*
+ * Parsing - JSON grammar-based parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://asmblah.github.com/parsing/
+ *
+ * Released under the MIT license
+ * https://github.com/asmblah/parsing/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    ParseException = require('../../../src/Exception/Parse'),
+    Parser = require('../../../src/Parser');
+
+// Note that these are not the same as Processors, which operate on a Rule's root Component
+describe('Parser grammar component match modifier', function () {
+    it('should support "what" component modifiers overriding the capture', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [{
+                            name: 'my_capture',
+                            what: /my\s+\w+/,
+                            modifier: function (capture) {
+                                // Override the captured string
+                                return '[my prefix]' + capture + '[my suffix]';
+                            }
+                        }]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            my_capture: '[my prefix]my\n text[my suffix]',
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 10,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+
+    it('should support "what" component modifiers reentering the parser', function () {
+        var grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [{
+                            name: 'my_capture',
+                            what: /my\s+\w+/,
+                            modifier: function (capture, parse) {
+                                return capture === 'my\n text' ?
+                                    parse('      my \n\n   differenttext  ') :
+                                    capture;
+                            }
+                        }]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text  ';
+
+        expect(parser.parse(code)).to.deep.equal({
+            name: 'my_rule',
+            // Note this capture was modified by the modifier
+            my_capture: {
+                name: 'my_rule',
+                my_capture: 'my \n\n   differenttext',
+                my_bounds: {
+                    start: {
+                        offset: 6,
+                        line: 1,
+                        column: 7
+                    },
+                    end: {
+                        offset: 27,
+                        line: 3,
+                        column: 17
+                    }
+                }
+            },
+            my_bounds: {
+                start: {
+                    offset: 2,
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    offset: 10,
+                    line: 2,
+                    column: 6
+                }
+            }
+        });
+    });
+
+    it('should support "what" component modifiers failing the parse', function () {
+        var caughtError,
+            grammarSpec = {
+                ignore: 'whitespace',
+                rules: {
+                    'my_rule': {
+                        components: [{
+                            name: 'my_capture',
+                            what: /my\s+\w+/,
+                            modifier: function (capture, parse, fail) {
+                                fail('My failure message', {my: 'context'});
+                            }
+                        }]
+                    },
+                    'whitespace': /\s+/,
+                },
+                start: 'my_rule',
+                bounds: 'my_bounds'
+            },
+            options = {
+                captureAllBounds: true
+            },
+            parser = new Parser(grammarSpec, null, options),
+            code = '  my\n text  ';
+
+        try {
+            parser.parse(code);
+        } catch (error) {
+            caughtError = error;
+        }
+
+        expect(caughtError).to.be.an.instanceOf(ParseException);
+        expect(caughtError.getMessage()).to.equal('My failure message');
+        expect(caughtError.getContext()).to.deep.equal({my: 'context'});
+        // Note that the whitespace after the match was not consumed, as the failure
+        // was explicitly raised in the modifier callback
+        expect(caughtError.getFurthestMatchEnd()).to.equal(10);
+        expect(caughtError.getLineNumber()).to.equal(2);
+        expect(caughtError.getText()).to.equal(code);
+        expect(caughtError.unexpectedEndOfInput()).to.be.false;
+    });
+});

--- a/test/unit/Parser/noMatchFailureTest.js
+++ b/test/unit/Parser/noMatchFailureTest.js
@@ -46,8 +46,9 @@ describe('Parser no match failures', function () {
 
         expect(caughtError).to.be.an.instanceOf(ParseException);
         expect(caughtError.getMessage()).to.equal('Parser.parse() :: No match');
-        expect(caughtError.getFurthestMatchEnd()).to.equal(-1);
-        expect(caughtError.getLineNumber()).to.equal(-1);
+        expect(caughtError.getStartOffset()).to.equal(-1);
+        expect(caughtError.getEndOffset()).to.equal(-1);
+        expect(caughtError.getEndLineNumber()).to.equal(-1);
         expect(caughtError.getText()).to.equal(code);
         expect(caughtError.unexpectedEndOfInput()).to.be.false;
     });

--- a/test/unit/Parser/oneOrMoreOfTest.js
+++ b/test/unit/Parser/oneOrMoreOfTest.js
@@ -71,7 +71,8 @@ describe('Parser "oneOrMoreOf" qualifier', function () {
             parser.parse(code);
         } catch (error) {
             expect(error.message).to.equal('Parser.parse() :: No match');
-            expect(error.getFurthestMatchEnd()).to.equal(-1);
+            expect(error.getStartOffset()).to.equal(-1);
+            expect(error.getEndOffset()).to.equal(-1);
             return;
         }
 

--- a/test/unit/Parser/partialMatchFailureTest.js
+++ b/test/unit/Parser/partialMatchFailureTest.js
@@ -36,7 +36,7 @@ describe('Parser partial match failures', function () {
                 bounds: 'my_bounds'
             },
             parser = new Parser(grammarSpec),
-            code = 'first \n\nbut not immediately second';
+            code = '  first \n\nbut not immediately second';
 
         try {
             parser.parse(code);
@@ -46,8 +46,10 @@ describe('Parser partial match failures', function () {
 
         expect(caughtError).to.be.an.instanceOf(ParseException);
         expect(caughtError.getMessage()).to.equal('Parser.parse() :: Unexpected "b"');
-        expect(caughtError.getFurthestMatchEnd()).to.equal(8);
-        expect(caughtError.getLineNumber()).to.equal(3);
+        // Note that the whitespace before the match _was_ consumed first
+        expect(caughtError.getStartOffset()).to.equal(2);
+        expect(caughtError.getEndOffset()).to.equal(10);
+        expect(caughtError.getEndLineNumber()).to.equal(3);
         expect(caughtError.getText()).to.equal(code);
         expect(caughtError.unexpectedEndOfInput()).to.be.false;
     });
@@ -106,7 +108,7 @@ describe('Parser partial match failures', function () {
             },
             stderr = {my: 'fake stderr'},
             parser = new Parser(grammarSpec, stderr),
-            code = 'first \n\nbut not immediately second',
+            code = '   first \n\nbut not immediately second',
             result;
 
         result = parser.parse(code);
@@ -115,8 +117,10 @@ describe('Parser partial match failures', function () {
         expect(result.stderr).to.equal(stderr);
         expect(result.parseException).to.be.an.instanceOf(ParseException);
         expect(result.parseException.getMessage()).to.equal('Parser.parse() :: Unexpected "b"');
-        expect(result.parseException.getFurthestMatchEnd()).to.equal(8);
-        expect(result.parseException.getLineNumber()).to.equal(3);
+        // Note that the whitespace before the match _was_ consumed first
+        expect(result.parseException.getStartOffset()).to.equal(3);
+        expect(result.parseException.getEndOffset()).to.equal(11);
+        expect(result.parseException.getEndLineNumber()).to.equal(3);
         expect(result.parseException.getText()).to.equal(code);
         expect(result.parseException.unexpectedEndOfInput()).to.be.false;
     });

--- a/test/unit/Parser/unexpectedEofFailureTest.js
+++ b/test/unit/Parser/unexpectedEofFailureTest.js
@@ -37,7 +37,7 @@ describe('Parser unexpected end-of-file failures', function () {
                 bounds: 'my_bounds'
             },
             parser = new Parser(grammarSpec),
-            code = 'first';
+            code = '   first';
 
         try {
             parser.parse(code);
@@ -47,8 +47,10 @@ describe('Parser unexpected end-of-file failures', function () {
 
         expect(caughtError).to.be.an.instanceOf(ParseException);
         expect(caughtError.getMessage()).to.equal('Parser.parse() :: Unexpected end of file');
-        expect(caughtError.getFurthestMatchEnd()).to.equal(5);
-        expect(caughtError.getLineNumber()).to.equal(1);
+        // Note that the whitespace before the match _was_ consumed first
+        expect(caughtError.getStartOffset()).to.equal(3);
+        expect(caughtError.getEndOffset()).to.equal(8);
+        expect(caughtError.getEndLineNumber()).to.equal(1);
         expect(caughtError.getText()).to.equal(code);
         expect(caughtError.unexpectedEndOfInput()).to.be.true;
     });


### PR DESCRIPTION
Adds support for component match `modifier` callback functions. These are similar to rule processors, however they operate on the match earlier and can be used for any component, unlike processors which can only exist on the root component of a rule.